### PR TITLE
add postgres database using docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,11 @@ jobs:
   build:
     docker:
       - image: circleci/golang:1.14
+      - image: postgres:12.2
+        environment:
+          - POSTGRES_USER=postgres
+          - POSTGRES_PASSWORD=1234
+          - POSTGRES_DB=db
     environment:
      ARTIFACTS: /tmp/artifacts
     steps:
@@ -15,6 +20,9 @@ jobs:
           git submodule update --init --recursive
       - run: go get github.com/jstemmer/go-junit-report
       - run:
+          name: Waiting for Postgres to be ready
+          command: ./scripts/wait_for_connection.sh localhost 5432
+      - run:
          name: Run unit tests
          command: |
           ./scripts/install_protoc.sh
@@ -25,6 +33,7 @@ jobs:
           mv coverage.html $ARTIFACTS/coverage.html
           cat unit_tests.out | go-junit-report > $ARTIFACTS/unit_tests.xml
           mkdir -p tmp
+          export P2PD_DATABASE_CONNECTIONPARAMS="sslmode=disable"
           make -B run-server-local &
           sleep 5
           go test -tags=integration_test ./test/integration/integration_test.go

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Test binary, build with `go test -c`
 *.test
 
+# Generated ssl certificates (for testing)
+certs
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ When cloning the repository, use `git clone --recursive <url>` to clone the subm
 Alternatively, run `git submodule update --init --recursive` within the repository root folder.
 
 Run `make setup` to setup the repository.
+You will need to setup a `postgresql` database connection in the configuration file (or via environment variables).  
+You can easily setup a running database using `docker-compose up db`  
 Once that is done, the server can be run locally using `make run-local-server`.
 A cli client tool can be used to interact with the server.
 Build it using `make client`.
@@ -21,6 +23,10 @@ Then run `./bin/p2pdclient` to see the list of available commands.
 
 ## Running using Docker
 
+### Docker Compose
+You can easily start and build the docker environment using `docker-compose`  
+To build from scratch the server use: `docker-compose up --build`
+ 
 ### Building the image
 
 In the root of the repository:
@@ -30,11 +36,15 @@ In the root of the repository:
 The name `p2pd-server` can be changed to any other docker compliant name.
 
 ### Running the container
-
-Once built, you can start running the server:
+Once built, you can start running the server (a database connection is necessary):
 
 `docker run -p 8080:8080 p2pd-server`
 
 If your image name is different, please use the one specified before. 
 The port the internal server is mapped to can be specified by changing the initial number of the pair, e.g.: `-p 5000:8080` to map to local port 5000.
 To run the container in the background use the `-d` flag.
+
+### Docker configuration
+You can override any variable from the configuration file `.yaml` using `environment variables` with this format `APPNAME_MY_PATH_TO_VARIABLE`  
+Exemple:  
+- To override the `database.host` property in configuration file : `P2PD_DATABASE_HOST=mynewhost`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+services:
+  server:
+    build:
+      context: .
+    image: docker.pkg.github.com/cryptogarageinc/p2pderivatives-server/server
+    environment: 
+      - P2PD_DATABASE_HOST=db
+    restart: always
+    depends_on:
+      - db
+    ports:
+      - 8080:8080
+
+  db:
+    image: "postgres:12.2"
+    command: | 
+      -c log_statement=all 
+      -c ssl=on
+      -c ssl_cert_file=/var/lib/postgresql/db.crt
+      -c ssl_key_file=/var/lib/postgresql/db.key   
+    restart: always
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=1234
+      - POSTGRES_DB=db
+    volumes:
+      - db-data:/var/lib/postgresql/data/ # persist data even if container shuts down
+      - ./certs/db.crt:/var/lib/postgresql/db.crt
+      - ./certs/db.key:/var/lib/postgresql/db.key   
+volumes:
+  db-data:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	bou.ke/monkey v1.0.2 // indirect
 	cloud.google.com/go v0.53.0 // indirect
+	github.com/apache/thrift v0.12.0 // indirect
 	github.com/bouk/monkey v1.0.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
@@ -16,14 +17,16 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
 	github.com/jhump/protoreflect v1.5.0
-	github.com/jinzhu/gorm v1.9.11
+	github.com/jinzhu/gorm v1.9.12
 	github.com/kr/text v0.2.0 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/lestrrat/go-envload v0.0.0-20180220120943-6ed08b54a570 // indirect
 	github.com/lestrrat/go-file-rotatelogs v0.0.0-20180223000712-d3151e2a480f
 	github.com/lestrrat/go-strftime v0.0.0-20180220042222-ba3bf9c1d042 // indirect
+	github.com/lib/pq v1.3.0 // indirect
 	github.com/mwitkow/go-proto-validators v0.2.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/openzipkin/zipkin-go v0.1.6 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/viper v1.5.0
@@ -31,8 +34,9 @@ require (
 	github.com/tebeka/strftime v0.1.3 // indirect
 	golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
-	google.golang.org/genproto v0.0.0-20200325114520-5b2d0af7952b // indirect
-	google.golang.org/grpc v1.28.0
+	golang.org/x/sys v0.0.0-20200406155108-e3b113bbe6a4 // indirect
+	google.golang.org/genproto v0.0.0-20200407120235-9eb9bb161a06 // indirect
+	google.golang.org/grpc v1.28.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.30.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3 h1:tkum0XDgfR0jcVVXuTsYv/erY2NnEDqwRojbxR1rBYA=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
+github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -86,6 +87,7 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -145,6 +147,8 @@ github.com/jhump/protoreflect v1.5.0 h1:NgpVT+dX71c8hZnxHof2M7QDK7QtohIJ7DYycjnk
 github.com/jhump/protoreflect v1.5.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jinzhu/gorm v1.9.11 h1:gaHGvE+UnWGlbWG4Y3FUwY1EcZ5n6S9WtqBA/uySMLE=
 github.com/jinzhu/gorm v1.9.11/go.mod h1:bu/pK8szGZ2puuErfU0RwyeNdsf3e6nCX/noXaVxkfw=
+github.com/jinzhu/gorm v1.9.12 h1:Drgk1clyWT9t9ERbzHza6Mj/8FY/CqMyVzOiHviMo6Q=
+github.com/jinzhu/gorm v1.9.12/go.mod h1:vhTjlKSJUTWNtcbQtrMBFCxy7eXTzeCAzfL5fBZT/Qs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.0.1 h1:HjfetcXq097iXP0uoPCdnM4Efp5/9MsM0/M+XOTeR3M=
@@ -177,10 +181,14 @@ github.com/lestrrat/go-strftime v0.0.0-20180220042222-ba3bf9c1d042 h1:Bvq8AziQ5j
 github.com/lestrrat/go-strftime v0.0.0-20180220042222-ba3bf9c1d042/go.mod h1:TPpsiPUEh0zFL1Snz4crhMlBe60PYxRHr5oFF3rRYg0=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
+github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v2.0.1+incompatible h1:xQ15muvnzGBHpIpdrNi1DA5x0+TcBZzsIDwmw9uTHzw=
+github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -266,6 +274,7 @@ golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -346,6 +355,8 @@ golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200406155108-e3b113bbe6a4 h1:c1Sgqkh8v6ZxafNGG64r8C8UisIW2TKMJN8P86tKjr0=
+golang.org/x/sys v0.0.0-20200406155108-e3b113bbe6a4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -419,8 +430,8 @@ google.golang.org/genproto v0.0.0-20191115194625-c23dd37a84c9/go.mod h1:n3cpQtvx
 google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200325114520-5b2d0af7952b h1:j5eujPLMak6H9l2EM381rW9X47/HPUyESXWJW9lVSsQ=
-google.golang.org/genproto v0.0.0-20200325114520-5b2d0af7952b/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200407120235-9eb9bb161a06 h1:9vfsGzoItEz6nXw6ZWaq6hbPviWbbkL3cO0qCIPJsh8=
+google.golang.org/genproto v0.0.0-20200407120235-9eb9bb161a06/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -434,8 +445,8 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
-google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
+google.golang.org/grpc v1.28.1 h1:C1QC6KzgSiLyBabDi87BbjaGreoRgGUF5nOyvfrAZ1k=
+google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/internal/database/orm/orm_config.go
+++ b/internal/database/orm/orm_config.go
@@ -2,6 +2,12 @@ package orm
 
 // Config contains the configuration parameter to set up the orm.
 type Config struct {
-	EnableLogging bool   `configkey:"database.log"`                          // Whether to enable logging of the database
-	DbFilePath    string `configkey:"database.filepath" validate:"required"` // The path to the file where to store the database
+	EnableLogging    bool   `configkey:"database.log"` // Whether to enable logging of the database
+	InMemory         bool   `configkey:"database.inmemory" default:"false"`
+	Host             string `configkey:"database.host" validate:"required"`
+	Port             string `configkey:"database.port" validate:"required"`
+	DbName           string `configkey:"database.dbname" default:"postgres"`
+	DbUser           string `configkey:"database.dbuser" default:"postgres"`
+	DbPassword       string `configkey:"database.dbpassword" validate:"required"`
+	ConnectionParams string `configkey:"database.connectionParams"` // Postgres sql connection parameters separate by space
 }

--- a/scripts/wait_for_connection.sh
+++ b/scripts/wait_for_connection.sh
@@ -1,0 +1,9 @@
+# $1 host parameter ex : localhost
+# $2 port parameter
+for i in `seq 1 10`;
+do
+  nc -z $1 $2 && echo Success && exit 0
+  echo -n .
+  sleep 1
+  done
+echo Failed waiting for $1:$2 && exit 1

--- a/test/config/integration.yaml
+++ b/test/config/integration.yaml
@@ -10,7 +10,11 @@ log:
   level: debug
 database:
   log: false
-  filepath: "./tmp/gorm.db"
+  host: localhost
+  port: 5432
+  dbuser: postgres
+  dbpassword: 1234
+  dbname: db
 app:
   token:
     secret: k^Cc#*mdnS9$nTOY6S1#1i7^e*o1ijSl #JWT secret key

--- a/test/config/unittest.yaml
+++ b/test/config/unittest.yaml
@@ -14,8 +14,11 @@ log:
   format: text
   level: debug
 database:
+  inmemory: true # ignored if environment flag is PRODUCTION
   log: false
-  filepath: ":memory:"
+  host: sqlite #mandatory fields but ignored when running with inmemory flag
+  port: 5432
+  dbpassword: 1234
 unittest:
   i: 10
   s: hoge


### PR DESCRIPTION
- Change `sqlite3` to `postgres` database (also configuration files)
- Keep only `sqlite3` for `unittest` environment
- Use docker `postgres` database as local
- Use `docker-compose` to build/run server and db as integration/prod
- Add `make gen-ssl-certs` to generate ssl certificates used by db (not used in ci, `docker volumes` cannot be used on circleci)
- Update `README.md` about database, docker-compose and environment variables